### PR TITLE
feat : 메인 로고 클릭 시 검색 결과 초기화 기능 추가

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -207,6 +207,7 @@ button {
   font-size: clamp(20px, 3.8vw, 68px);
   font-weight: 600;
   color: #78ce85;
+	cursor:pointer;
 }
 
 .search-form {

--- a/lib/son/search.js
+++ b/lib/son/search.js
@@ -2,6 +2,7 @@ import { getNode, dummyJobPostings, dataProcessing, renderJobs } from '../index.
 
 const searchForm = getNode('.search-form');
 const searchText = getNode('#search-text');
+const mainLogo = getNode('.main-header-title');
 
 let searchWord;
 let data = [];
@@ -26,6 +27,10 @@ searchForm.addEventListener('submit', (e) => {
 	console.log('검색어 : ');
 	console.log(searchWord);
 	renderJobs(findKeyWord(data, searchWord));
+})
+
+mainLogo.addEventListener('click', () => {
+	renderJobs(data);
 })
 
 


### PR DESCRIPTION
<사용자가 특정 기업명을 검색한 후, 전체 목록으로 되돌아갈 수 있는 방법이 없는 문제>
좌측 상단의 메인 로고를 클릭하여 공고 리스트를 초기화하는 기능을 추가했습니다.
메인 로고 css에 `cursor:pointer` 값을 주어 사용자가 클릭할 수 있는 오브젝트로  인식하도록 했습니다.
