### PR TITLE
feat : 메인 로고 클릭 시 검색 결과 초기화 기능 추가

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -207,6 +207,7 @@ button {
   font-size: clamp(20px, 3.8vw, 68px);
   font-weight: 600;
   color: #78ce85;
+	cursor:pointer;
 }
 
 .search-form {

--- a/lib/son/search.js
+++ b/lib/son/search.js
@@ -30,6 +30,7 @@ searchForm.addEventListener('submit', (e) => {
 })
 
 mainLogo.addEventListener('click', () => {
+	searchText.value = '';
 	renderJobs(data);
 })
 

--- a/lib/son/search.js
+++ b/lib/son/search.js
@@ -2,6 +2,7 @@ import { getNode, dummyJobPostings, dataProcessing, renderJobs } from '../index.
 
 const searchForm = getNode('.search-form');
 const searchText = getNode('#search-text');
+const mainLogo = getNode('.main-header-title');
 
 let searchWord;
 let data = [];
@@ -26,6 +27,10 @@ searchForm.addEventListener('submit', (e) => {
 	console.log('검색어 : ');
 	console.log(searchWord);
 	renderJobs(findKeyWord(data, searchWord));
+})
+
+mainLogo.addEventListener('click', () => {
+	renderJobs(data);
 })
 
 

--- a/lib/son/search.js
+++ b/lib/son/search.js
@@ -1,14 +1,21 @@
-import { getNode, dummyJobPostings, dataProcessing, renderJobs } from '../index.js'
+import { getNode, dataProcessing, getPosting, getSessionStorage, setSessionStorage, postRender } from '../index.js'
 
 const searchForm = getNode('.search-form');
 const searchText = getNode('#search-text');
 const mainLogo = getNode('.main-header-title');
 
 let searchWord;
-let data = [];
 
 window.addEventListener('load', () => {
-	data = dataProcessing(dummyJobPostings); //처음 페이지 로딩될 때 실행하기
+	(async () => {
+		const response = await getPosting();	
+		if (response.result === 'success'){
+			
+			setSessionStorage(dataProcessing(response.postings));
+		}
+		else
+			console.error('Posting download error!');
+	})();
 })
 
 function isEmpty(input){
@@ -26,12 +33,13 @@ searchForm.addEventListener('submit', (e) => {
 	searchWord = searchText.value.toLowerCase().split(' ');
 	console.log('검색어 : ');
 	console.log(searchWord);
-	renderJobs(findKeyWord(data, searchWord));
+	// postRender(findKeyWord(data, searchWord));
+	postRender(findKeyWord(getSessionStorage(), searchWord));
 })
 
 mainLogo.addEventListener('click', () => {
 	searchText.value = '';
-	renderJobs(data);
+	postRender(getSessionStorage());
 })
 
 


### PR DESCRIPTION
1. 좌측 상단의 메인 로고를 클릭하여 공고 리스트를 초기화하는 기능을 추가했습니다.
  - 메인 로고 css에 cursor:pointer 값을 주어 사용자가 클릭할 수 있는 오브젝트로 인식하도록 했습니다.
  - 메인 로고 클릭 시 검색란을 비웁니다.
2. 로컬 dummyData 대신 `getPosting()`을 사용하여 온라인에서 JSON 파일을 받아와서 사용하도록 수정했습니다.
  - 기존에는 dummyData를 전처리한 값을 전역에서 관리했는데, getSessionStorage()로 관리.
3. 검색 결과 렌더링 방식을 창식님 렌더링 방식에서 소영님 렌더링 방식으로 수정했습니다.